### PR TITLE
Bump Mongoengine to 0.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import find_packages, setup
 
 REQUIRES = [
     "pymongo==2.8",
-    "mongoengine==0.8.7",
+    "mongoengine==0.9.0",
     "pyramid"
 ]
 
@@ -39,7 +39,7 @@ def readme():
 
 setup(
     name="pyramid-mongoengine",
-    version="0.0.2",
+    version="0.0.3",
     description="Mongoengine Pyramid extension based in flask-mongoengine",
     long_description=readme(),
     url="https://github.com/marioidival/pyramid_mongoengine",


### PR DESCRIPTION
The MongoEngine under tag 0.9.0 is much stabler than whats in MASTER at the moment, and has the side-effect of pulling in full text search support so you can do things like:

document = Song.objects.search_text('trap')

 len(document)
 22

so long as you append a meta index to your object that defines the text_search index like so:

```
meta = {'indexes': [                                                                                                                                                                                           
                 {'fields': ['$title', '$artist', '$album', '$tags'],                                                                                                                                               
                  'default_language': 'english',                                                                                                                                                                    
                  'weight': {'title': 10, 'tags': 9, 'artist': 8, 'album': 6}                                                                                                                                       
                 }                                                                                                                                                                                                  
             ]} 
```
