### PR TITLE
Adding support for replicaSets in pyramid-mongoengine

### DIFF
--- a/pyramid_mongoengine/__init__.py
+++ b/pyramid_mongoengine/__init__.py
@@ -54,7 +54,7 @@ def _connect_database(config):
     mongodb_user = None
     mongodb_pass = None
 
-    if settings.get("mongodb_url"):
+    if settings.get("mongo_url"):
         mongodb_url = settings["mongo_url"]
 
     if settings.get("mongodb_name"):
@@ -70,6 +70,12 @@ def _connect_database(config):
     if settings.get("mongodb_password"):
         mongodb_pass = settings["mongodb_password"]
 
+    #print(f"""MongoEngine params:
+    #      \t{mongodb_name}
+    #      \t{mongodb_url}
+    #      \t{mongodb_user}
+    #      \t{mongodb_pass}
+    #      \t{mongodb_rs}""")
 
     if not mongodb_user and mongodb_rs: # with no user and replicaSet
         from pymongo import ReadPreference

--- a/pyramid_mongoengine/__init__.py
+++ b/pyramid_mongoengine/__init__.py
@@ -48,16 +48,28 @@ def _connect_database(config):
     """
     settings = config.registry.settings
 
-    mongo_uri = "mongodb://localhost:27017"
+    mongodb_url = "mongodb://localhost:27017"
     mongodb_name = "test"
+    mongodb_rs = None
 
-    if settings.get("mongo_url"):
-        mongo_uri = settings["mongo_url"]
+    if settings.get("mongodb_url"):
+        mongodb_url = settings["mongodb_url"]
 
     if settings.get("mongodb_name"):
         mongodb_name = settings["mongodb_name"]
 
-    return mongoengine.connect(mongodb_name, host=mongo_uri)
+    if settings.get("mongodb_replicaset"):
+        from pymongo import ReadPreference
+        mongodb_replicaset = settings["mongodb_replicaset"]
+        mongo_connection = mongoengine.connect(
+            mongodb_name,
+            host=mongodb_url,
+            replicaSet=mongodb_replicaset,
+            read_preference=ReadPreference.SECONDARY_PREFERRED)
+    else:
+        mongo_connection = mongoengine.connect(mongodb_name, host=mongodb_url)
+
+    return mongo_connection
 
 
 class MongoEngine(object):

--- a/pyramid_mongoengine/__init__.py
+++ b/pyramid_mongoengine/__init__.py
@@ -53,18 +53,23 @@ def _connect_database(config):
     mongodb_rs = None
 
     if settings.get("mongodb_url"):
-        mongodb_url = settings["mongodb_url"]
+        mongodb_url = settings["mongo_url"]
 
     if settings.get("mongodb_name"):
         mongodb_name = settings["mongodb_name"]
+        if "?" in mongodb_name:
+            mongodb_rs = mongodb_name.split('?')[1].split("=")[1]
+            mongodb_name = mongodb_name.split('?')[0]
 
     if settings.get("mongodb_replicaset"):
+        mongodb_rs = settings["mongodb_replicaset"]
+
+    if mongodb_rs:
         from pymongo import ReadPreference
-        mongodb_replicaset = settings["mongodb_replicaset"]
         mongo_connection = mongoengine.connect(
             mongodb_name,
             host=mongodb_url,
-            replicaSet=mongodb_replicaset,
+            replicaSet=mongodb_rs,
             read_preference=ReadPreference.SECONDARY_PREFERRED)
     else:
         mongo_connection = mongoengine.connect(mongodb_name, host=mongodb_url)

--- a/pyramid_mongoengine/__init__.py
+++ b/pyramid_mongoengine/__init__.py
@@ -70,13 +70,6 @@ def _connect_database(config):
     if settings.get("mongodb_password"):
         mongodb_pass = settings["mongodb_password"]
 
-    #print(f"""MongoEngine params:
-    #      \t{mongodb_name}
-    #      \t{mongodb_url}
-    #      \t{mongodb_user}
-    #      \t{mongodb_pass}
-    #      \t{mongodb_rs}""")
-
     if not mongodb_user and mongodb_rs: # with no user and replicaSet
         from pymongo import ReadPreference
         mongo_connection = mongoengine.connect(

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def readme():
 
 setup(
     name="pyramid-mongoengine",
-    version="0.0.9",
+    version="0.0.10",
     description="Mongoengine Pyramid extension based in flask-mongoengine",
     long_description=readme(),
     url="https://github.com/marioidival/pyramid_mongoengine",


### PR DESCRIPTION
Please find below the code slightly adapted in order to support a replicaSet cluster of mongoDB databases