### PR TITLE
docs: Fix simple typo, requred -> required

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ db = MongoEngine()
 
 class User(db.Document):
     email = db.StringField(required=True)
-    username = db.StringField(requred=True)
+    username = db.StringField(required=True)
 
 ```
 


### PR DESCRIPTION
There is a small typo in README.md.

Should read `required` rather than `requred`.

